### PR TITLE
fix: 初期化エラーを修正 - null参照による addEventListener エラーを解決

### DIFF
--- a/app.js
+++ b/app.js
@@ -202,39 +202,55 @@ class AikidoExamApp {
         const sequentialReadingBtn = document.getElementById('sequential-reading-btn');
         const stopSpeechBtn = document.getElementById('stop-speech-btn');
 
-        examCategorySelect.addEventListener('change', () => {
-            this.onExamCategoryChange();
-        });
+        if (examCategorySelect) {
+            examCategorySelect.addEventListener('change', () => {
+                this.onExamCategoryChange();
+            });
+        }
 
-        gradeSelect.addEventListener('change', () => {
-            this.onGradeChange();
-        });
+        if (gradeSelect) {
+            gradeSelect.addEventListener('change', () => {
+                this.onGradeChange();
+            });
+        }
 
-        showAllSubjectsBtn.addEventListener('click', () => {
-            this.showAllTechniques();
-            this.updateButtonVisibility(false);
-        });
+        if (showAllSubjectsBtn) {
+            showAllSubjectsBtn.addEventListener('click', () => {
+                this.showAllTechniques();
+                this.updateButtonVisibility(false);
+            });
+        }
 
-        showDesignatedBtn.addEventListener('click', () => {
-            this.showDesignatedTechniques();
-            this.updateButtonVisibility(true);
-        });
+        if (showDesignatedBtn) {
+            showDesignatedBtn.addEventListener('click', () => {
+                this.showDesignatedTechniques();
+                this.updateButtonVisibility(true);
+            });
+        }
 
-        randomSelectBtn.addEventListener('click', () => {
-            this.selectRandomTechnique();
-        });
+        if (randomSelectBtn) {
+            randomSelectBtn.addEventListener('click', () => {
+                this.selectRandomTechnique();
+            });
+        }
 
-        randomDesignatedBtn.addEventListener('click', () => {
-            this.selectRandomDesignatedTechnique();
-        });
+        if (randomDesignatedBtn) {
+            randomDesignatedBtn.addEventListener('click', () => {
+                this.selectRandomDesignatedTechnique();
+            });
+        }
 
-        sequentialReadingBtn.addEventListener('click', () => {
-            this.startSequentialReading();
-        });
+        if (sequentialReadingBtn) {
+            sequentialReadingBtn.addEventListener('click', () => {
+                this.startSequentialReading();
+            });
+        }
 
-        stopSpeechBtn.addEventListener('click', () => {
-            this.stopSpeech();
-        });
+        if (stopSpeechBtn) {
+            stopSpeechBtn.addEventListener('click', () => {
+                this.stopSpeech();
+            });
+        }
 
         // 検索モードのイベントリスナー
         const searchBtn = document.getElementById('search-btn');
@@ -242,24 +258,32 @@ class AikidoExamApp {
         const showAllTechniquesBtn = document.getElementById('show-all-techniques-btn');
         const searchText = document.getElementById('search-text');
 
-        searchBtn.addEventListener('click', () => {
-            this.performSearch();
-        });
+        if (searchBtn) {
+            searchBtn.addEventListener('click', () => {
+                this.performSearch();
+            });
+        }
 
-        clearSearchBtn.addEventListener('click', () => {
-            this.clearSearch();
-        });
+        if (clearSearchBtn) {
+            clearSearchBtn.addEventListener('click', () => {
+                this.clearSearch();
+            });
+        }
 
-        showAllTechniquesBtn.addEventListener('click', () => {
-            this.showAllTechniquesInSearch();
-        });
+        if (showAllTechniquesBtn) {
+            showAllTechniquesBtn.addEventListener('click', () => {
+                this.showAllTechniquesInSearch();
+            });
+        }
 
         // キーワード検索でEnterキー押下時に検索実行
-        searchText.addEventListener('keypress', (e) => {
-            if (e.key === 'Enter') {
-                this.performSearch();
-            }
-        });
+        if (searchText) {
+            searchText.addEventListener('keypress', (e) => {
+                if (e.key === 'Enter') {
+                    this.performSearch();
+                }
+            });
+        }
 
         // チェックボックスの変更でリアルタイム検索
         document.querySelectorAll('.category-filter, .attack-filter, .position-filter').forEach(checkbox => {


### PR DESCRIPTION
## Summary
アプリ初期化時に発生していた `Cannot read properties of null (reading 'addEventListener')` エラーを修正しました。

## 問題の詳細
`setupEventListeners()` メソッドで、存在しない要素に対して `addEventListener` を呼び出そうとしていたため、初期化エラーが発生していました。

## 修正内容
- **null チェックの追加**: 全ての `getElementById()` の結果に対して存在チェックを実装
- **安全なイベントリスナー設定**: 要素が存在する場合のみ `addEventListener` を呼び出す
- **審査支援モードの要素**: 全ての審査関連ボタンに対して安全性を確保
- **検索モードの要素**: 検索関連の入力要素とボタンにも同様の対処を実施

## 技術的な変更
```javascript
// 修正前
showAllSubjectsBtn.addEventListener('click', () => {
    this.showAllTechniques();
});

// 修正後
if (showAllSubjectsBtn) {
    showAllSubjectsBtn.addEventListener('click', () => {
        this.showAllTechniques();
    });
}
```

## Test plan
- [x] アプリが初期化エラーなしで起動することを確認
- [x] ランディングページから正常に遷移できることを確認
- [x] 審査支援モードが正常に表示されることを確認
- [x] 検索モードへの切り替えが正常に動作することを確認
- [x] Playwright でのテストが成功することを確認

## 関連 PR
- #2 指定技表示・ランダム選択機能の修正

🤖 Generated with [Claude Code](https://claude.ai/code)