### PR TITLE
fix: 昇段審査で初段自動選択を再実装し、技一覧表示を修正

### DIFF
--- a/.github/pr-auto-open.md
+++ b/.github/pr-auto-open.md
@@ -1,0 +1,20 @@
+# GitHub PR 自動オープンルール
+
+## ルール
+Claude Codeで`gh pr create`コマンドを実行してPRを作成した場合、自動的にBraveブラウザでPRのURLを開く。
+
+## 実装方法
+1. `gh pr create`の実行後、出力されたPR URLを取得
+2. `open -a "Brave Browser" [PR_URL]`コマンドを実行
+
+## 使用例
+```bash
+# PRを作成
+PR_URL=$(gh pr create --title "..." --body "...")
+
+# Braveブラウザで開く
+open -a "Brave Browser" "$PR_URL"
+```
+
+## Claude Codeでの適用
+Claude Codeがこのルールに従って、PR作成後は自動的にBraveブラウザでPRページを開きます。

--- a/app.js
+++ b/app.js
@@ -787,13 +787,20 @@ class AikidoExamApp {
             });
             gradeSelection.style.display = 'block';
             
+            // 昇段審査の場合は初段を自動選択
+            if (examCategory === '昇段審査' && grades.includes('初段')) {
+                gradeSelect.value = '初段';
+                // 級・段選択のイベントを手動で発火
+                this.onGradeChange();
+            } else {
+                // 昇段審査以外の場合のみ技術セクションを非表示にする
+                console.log('技術セクションを非表示にします');
+                techniqueSection.style.display = 'none';
+            }
         } else {
             console.log('審査データが見つかりません');
+            techniqueSection.style.display = 'none';
         }
-
-        // 技術セクションを非表示にする
-        console.log('技術セクションを非表示にします');
-        techniqueSection.style.display = 'none';
         console.log('=== onExamCategoryChange 終了 ===');
     }
 


### PR DESCRIPTION
## Summary
昇段審査で級・段を選択しても技一覧が表示されない問題を修正しました。

## 問題の詳細
- 昇段審査を選択した際、初段が自動選択されなくなっていた
- 級・段を手動で選択しても、技術セクションが非表示のままになっていた

## 修正内容
1. **初段自動選択の再実装**
   - 昇段審査選択時に初段を自動的に選択
   - 選択後に`onGradeChange()`を呼び出して技一覧を表示

2. **技術セクション表示制御の修正**
   - 昇段審査の場合は自動選択後に技術セクションを表示
   - それ以外の審査区分では従来通り非表示にする

3. **ドキュメント追加**
   - PR作成時にBraveブラウザで自動的に開くルールを文書化

## Test plan
- [x] 昇段審査を選択すると初段が自動選択されることを確認
- [x] 初段選択後に技一覧が自動的に表示されることを確認
- [x] 昇級審査や有段審査でも級・段選択後に技一覧が表示されることを確認
- [x] 他の審査区分の動作に影響がないことを確認

## 関連PR
- #2 指定技表示・ランダム選択機能の修正
- #3 初期化エラーの修正

🤖 Generated with [Claude Code](https://claude.ai/code)